### PR TITLE
fix NullPointerException in createCertData(..)

### DIFF
--- a/sdk/src/main/java/io/github/mytargetsdk/CertLoader.java
+++ b/sdk/src/main/java/io/github/mytargetsdk/CertLoader.java
@@ -69,7 +69,10 @@ final class CertLoader
 						final String alias = aliases.nextElement();
 						final X509Certificate cert = (X509Certificate) ks.getCertificate(alias);
 
-						certificates.add(cert);
+						if (cert != null)
+						{
+							certificates.add(cert);
+						}
 					}
 					catch (Throwable throwable)
 					{


### PR DESCRIPTION
fix method io.github.mytargetsdk.CertLoader#getSystemCerts to skip null "cert" values